### PR TITLE
Update constructors to return values instead of pointers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 test:
-	go test -race ./...
+	go test -race ./... -count=1

--- a/uri/domain_name/DomainName.go
+++ b/uri/domain_name/DomainName.go
@@ -28,7 +28,7 @@ func (dn *DomainName) Value() string {
 	return dn.value
 }
 
-func (dn *DomainName) Equals(compare *DomainName) bool {
+func (dn *DomainName) Equals(compare DomainName) bool {
 	return dn.Value() == compare.Value()
 }
 

--- a/uri/domain_name/DomainName.go
+++ b/uri/domain_name/DomainName.go
@@ -9,17 +9,17 @@ type DomainName struct {
 	value string
 }
 
-func New(value string) (*DomainName, error) {
+func New(value string) (DomainName, error) {
 	length := len([]rune(value))
 	if length < 1 || length > 255 {
-		return &DomainName{}, errors.New("The domain name value must be atleast one (1) character, and no greather than two-hundred fifty-five (255) characters.")
+		return DomainName{}, errors.New("The domain name value must be atleast one (1) character, and no greather than two-hundred fifty-five (255) characters.")
 	}
 
 	if !isValidDomainNameValue(value) {
-		return &DomainName{}, errors.New("The domain name can only be ASCII characters and hyphens.  The domain name cannot start with a hyphen.")
+		return DomainName{}, errors.New("The domain name can only be ASCII characters and hyphens.  The domain name cannot start with a hyphen.")
 	}
 
-	return &DomainName{
+	return DomainName{
 		value: value,
 	}, nil
 }

--- a/uri/domain_name/DomainName_test.go
+++ b/uri/domain_name/DomainName_test.go
@@ -77,7 +77,7 @@ func Test_TwoSameDomainNameMustEqual(t *testing.T) {
 func Test_MustReturnErrorForEmptyString(t *testing.T) {
 
 	// Arrange & Act
-	tld, err := New("")
+	_, err := New("")
 
 	// Assert
 	// Fatal use to end test if an error obejct was not returned because the expessions after this evaluate the error object
@@ -88,9 +88,6 @@ func Test_MustReturnErrorForEmptyString(t *testing.T) {
 	expectedMessage := "The domain name value must be atleast one (1) character, and no greather than two-hundred fifty-five (255) characters."
 	if err.Error() != expectedMessage {
 		t.Errorf("The exptected error was not returned. \n Actual: %s \n Expected: %s", err.Error(), expectedMessage)
-	}
-	if tld == nil {
-		t.Error("Expected an instantiated, empty, DomainName object, but got a 'nil' value.")
 	}
 
 }
@@ -104,7 +101,7 @@ func Test_MustReturnErrorForStringMoreThan255Characters(t *testing.T) {
 	}
 
 	// Act
-	tld, err := New(testString)
+	_, err := New(testString)
 
 	// Assert
 	// Fatal use to end test if an error obejct was not returned because the expessions after this evaluate the error object
@@ -116,16 +113,13 @@ func Test_MustReturnErrorForStringMoreThan255Characters(t *testing.T) {
 	if err.Error() != expectedMessage {
 		t.Errorf("The exptected error was not returned. \n Actual: %s \n Expected: %s", err.Error(), expectedMessage)
 	}
-	if tld == nil {
-		t.Error("Expected an instantiated, empty, TopLeveLDomain object, but got a 'nil' value.")
-	}
 
 }
 
 func Test_MustReturnErrorStringStartingWithDash(t *testing.T) {
 
 	// Arrange & Act
-	tld, err := New("-attestify")
+	_, err := New("-attestify")
 
 	// Assert
 	// Fatal use to end test if an error obejct was not returned because the expessions after this evaluate the error object
@@ -136,9 +130,6 @@ func Test_MustReturnErrorStringStartingWithDash(t *testing.T) {
 	expectedMessage := "The domain name can only be ASCII characters and hyphens.  The domain name cannot start with a hyphen."
 	if err.Error() != expectedMessage {
 		t.Errorf("The exptected error was not returned. \n Actual: %s \n Expected: %s", err.Error(), expectedMessage)
-	}
-	if tld == nil {
-		t.Error("Expected an instantiated, empty, TopLeveLDomain object, but got a 'nil' value.")
 	}
 
 }

--- a/uri/domain_name/DomainName_test.go
+++ b/uri/domain_name/DomainName_test.go
@@ -4,10 +4,14 @@ import (
 	"testing"
 )
 
+func setup(t *testing.T) {
+	t.Parallel()
+}
+
 /** Happy Path Tests **/
 
 func Test_InstantiateDomainName(t *testing.T) {
-
+	setup(t)
 	tld, err := New("attestify")
 
 	// Fatal use to end test if an error obejct was not returned because the expessions after this evaluate the error object
@@ -22,7 +26,7 @@ func Test_InstantiateDomainName(t *testing.T) {
 }
 
 func Test_InstantiateForStringOfExactly255Characters(t *testing.T) {
-
+	setup(t)
 	// Arrange - Generate a string of eactly 255 characters
 	testString := ""
 	for i := 1; i <= 255; i++ {
@@ -40,7 +44,7 @@ func Test_InstantiateForStringOfExactly255Characters(t *testing.T) {
 }
 
 func Test_InstantiateForStringWithDash(t *testing.T) {
-
+	setup(t)
 	// Act
 	tld, err := New("attestify-site")
 
@@ -55,7 +59,7 @@ func Test_InstantiateForStringWithDash(t *testing.T) {
 }
 
 func Test_TwoSameDomainNameMustEqual(t *testing.T) {
-
+	setup(t)
 	// Act
 	dn1, err := New("attestify")
 	dn2, err := New("attestify")
@@ -75,7 +79,7 @@ func Test_TwoSameDomainNameMustEqual(t *testing.T) {
 /** Sad Path Tests **/
 
 func Test_MustReturnErrorForEmptyString(t *testing.T) {
-
+	setup(t)
 	// Arrange & Act
 	_, err := New("")
 
@@ -93,7 +97,7 @@ func Test_MustReturnErrorForEmptyString(t *testing.T) {
 }
 
 func Test_MustReturnErrorForStringMoreThan255Characters(t *testing.T) {
-
+	setup(t)
 	// Arrange - Generate a string of 256 characters
 	testString := ""
 	for i := 1; i <= 256; i++ {
@@ -117,7 +121,7 @@ func Test_MustReturnErrorForStringMoreThan255Characters(t *testing.T) {
 }
 
 func Test_MustReturnErrorStringStartingWithDash(t *testing.T) {
-
+	setup(t)
 	// Arrange & Act
 	_, err := New("-attestify")
 
@@ -135,7 +139,7 @@ func Test_MustReturnErrorStringStartingWithDash(t *testing.T) {
 }
 
 func Test_TwoDifferentTopLevelDomainMustNotEqual(t *testing.T) {
-
+	setup(t)
 	// Act
 	dn1, err := New("attestify")
 	dn2, err := New("billbensing")

--- a/uri/host/host.go
+++ b/uri/host/host.go
@@ -9,8 +9,8 @@ type Host struct {
 	value string
 }
 
-func NewFromRegisteredName(regName registered_name.RegisteredName) (*Host, error) {
-	return &Host {
+func NewFromRegisteredName(regName registered_name.RegisteredName) (Host, error) {
+	return Host {
 		hostType: "reg-name",
 		value: regName.Value(),
 	}, nil

--- a/uri/host/host_test.go
+++ b/uri/host/host_test.go
@@ -5,12 +5,16 @@ import (
 	"testing"
 )
 
+func setup(t *testing.T) {
+	t.Parallel()
+}
+
 /** Happy Path Tests **/
 
 // Instantiate a Host object using the NewFromRegisteredName constructor without an error
 // and expect the .Value() to be "attestify.io" and .HostType() to be "reg-name".
 func Test_InstantiateHost(t *testing.T) {
-
+	setup(t)
 	regname, _ := registered_name.NewFromString("attestify.io")
 	host, err := NewFromRegisteredName(regname)
 

--- a/uri/host/host_test.go
+++ b/uri/host/host_test.go
@@ -12,7 +12,7 @@ import (
 func Test_InstantiateHost(t *testing.T) {
 
 	regname, _ := registered_name.NewFromString("attestify.io")
-	host, err := NewFromRegisteredName(*regname)
+	host, err := NewFromRegisteredName(regname)
 
 	// Fatal use to end test if an error object was not returned because the expressions after this evaluate the error object
 	if err != nil {

--- a/uri/registered_name/RegisteredName.go
+++ b/uri/registered_name/RegisteredName.go
@@ -29,7 +29,7 @@ func New(tld string, domainName string) (*RegisteredName, error) {
 
 	return &RegisteredName{
 		tld:        *tldInstance,
-		domainName: *domainNameInstance,
+		domainName: domainNameInstance,
 	}, nil
 }
 

--- a/uri/registered_name/RegisteredName.go
+++ b/uri/registered_name/RegisteredName.go
@@ -28,7 +28,7 @@ func New(tld string, domainName string) (*RegisteredName, error) {
 	}
 
 	return &RegisteredName{
-		tld:        *tldInstance,
+		tld:        tldInstance,
 		domainName: domainNameInstance,
 	}, nil
 }

--- a/uri/registered_name/RegisteredName.go
+++ b/uri/registered_name/RegisteredName.go
@@ -16,18 +16,18 @@ type RegisteredName struct {
 
 // New Instantiates a RegisteredName class from separated top level domain
 // and domain name string objects.
-func New(tld string, domainName string) (*RegisteredName, error) {
+func New(tld string, domainName string) (RegisteredName, error) {
 	tldInstance, err := top_level_domain.New(tld)
 	if err != nil {
-		return &RegisteredName{}, generateError(err)
+		return RegisteredName{}, generateError(err)
 	}
 
 	domainNameInstance, err := domain_name.New(domainName)
 	if err != nil {
-		return &RegisteredName{}, generateError(err)
+		return RegisteredName{}, generateError(err)
 	}
 
-	return &RegisteredName{
+	return RegisteredName{
 		tld:        tldInstance,
 		domainName: domainNameInstance,
 	}, nil
@@ -35,7 +35,7 @@ func New(tld string, domainName string) (*RegisteredName, error) {
 
 // NewFromString Instantiates a RegisteredName class from a
 // full registered name string.  Example: "attestify.io"
-func NewFromString(registeredName string) (*RegisteredName, error) {
+func NewFromString(registeredName string) (RegisteredName, error) {
 
 	tld := registeredName[strings.LastIndex(registeredName, ".")+1:]
 	domainName := strings.TrimRight(registeredName,"."+tld)

--- a/uri/registered_name/RegisteredName.go
+++ b/uri/registered_name/RegisteredName.go
@@ -57,6 +57,6 @@ func (rn *RegisteredName) Value() string {
 
 // Equals compares the current RegisteredName to another instance
 // of a RegisteredName object to asses equality
-func (rn *RegisteredName) Equals(compare *RegisteredName) bool {
+func (rn *RegisteredName) Equals(compare RegisteredName) bool {
 	return rn.Value() == compare.Value()
 }

--- a/uri/registered_name/RegisteredName_test.go
+++ b/uri/registered_name/RegisteredName_test.go
@@ -4,13 +4,17 @@ import (
 	"testing"
 )
 
+func setup(t *testing.T) {
+	t.Parallel()
+}
+
 /** Happy Path Tests **/
 
 // Instantiate a RegisteredName object using a top level domain of "io", and a doming name
 // "attestify", without receiving an error. Validate state of the object by expecting the
 // .Value() to return "attestify.io"
 func Test_InstantiateRegisteredName(t *testing.T) {
-
+	setup(t)
 	registeredName, err := New("io", "attestify")
 
 	// Fatal use to end test if an error obejct was not returned because the expessions after this evaluate the error object
@@ -28,7 +32,7 @@ func Test_InstantiateRegisteredName(t *testing.T) {
 }
 
 func Test_InstantiateRegisteredNameFromString(t *testing.T) {
-
+	setup(t)
 	registeredName, err := NewFromString("attestify.io")
 
 	// Fatal use to end test if an error obejct was not returned because the expessions after this evaluate the error object
@@ -46,7 +50,7 @@ func Test_InstantiateRegisteredNameFromString(t *testing.T) {
 }
 
 func Test_InstantiateRegisteredNameFromStringWithSubDomain(t *testing.T) {
-
+	setup(t)
 	registeredName, err := NewFromString("subdomain.attestify.io")
 
 	// Fatal use to end test if an error objet was not returned because the expressions after this evaluate the error object
@@ -64,7 +68,7 @@ func Test_InstantiateRegisteredNameFromStringWithSubDomain(t *testing.T) {
 }
 
 func Test_TwoSameRegisteredNameMustEqual(t *testing.T) {
-
+	setup(t)
 	// Act
 	rn1, err := New("io", "attestify")
 	rn2, err := New("io", "attestify")
@@ -83,7 +87,7 @@ func Test_TwoSameRegisteredNameMustEqual(t *testing.T) {
 /** Sad Path Tests **/
 
 func Test_TwoDifferentTopLevelDomainMustNotEqual(t *testing.T) {
-
+	setup(t)
 	// Act
 	rn1, err := New("io", "attestify")
 	rn2, err := New("com", "attestify")
@@ -101,7 +105,7 @@ func Test_TwoDifferentTopLevelDomainMustNotEqual(t *testing.T) {
 }
 
 func Test_HandleTopLevelDomainError(t *testing.T) {
-
+	setup(t)
 	// Arrange & Act - provide a bad top level domain
 	_, err := New("bad!", "attestify")
 
@@ -112,7 +116,7 @@ func Test_HandleTopLevelDomainError(t *testing.T) {
 }
 
 func Test_HandleDomainNameError(t *testing.T) {
-
+	setup(t)
 	// Arrange & Act - provide a bad domain name
 	_, err := New("io", "-attestify")
 

--- a/uri/registered_name/RegisteredName_test.go
+++ b/uri/registered_name/RegisteredName_test.go
@@ -103,31 +103,22 @@ func Test_TwoDifferentTopLevelDomainMustNotEqual(t *testing.T) {
 func Test_HandleTopLevelDomainError(t *testing.T) {
 
 	// Arrange & Act - provide a bad top level domain
-	registeredName, err := New("bad!", "attestify")
+	_, err := New("bad!", "attestify")
 
 	// Fatal use to end test if an error obejct was not returned because the expessions after this evaluate the error object
 	if err == nil {
 		t.Fatalf("An error was expected, but no error was returned")
 	}
-
-	if registeredName == nil {
-		t.Error("Expected an instantiated, empty, RegisteredName object, but got a 'nil' value.")
-	}
-
-
 }
 
 func Test_HandleDomainNameError(t *testing.T) {
 
 	// Arrange & Act - provide a bad domain name
-	registeredName, err := New("io", "-attestify")
+	_, err := New("io", "-attestify")
 
 	// Fatal use to end test if an error obejct was not returned because the expessions after this evaluate the error object
 	if err == nil {
 		t.Fatalf("An error was expected, but no error was returned")
 	}
 
-	if registeredName == nil {
-		t.Error("Expected an instantiated, empty, RegisteredName object, but got a 'nil' value.")
-	}
 }

--- a/uri/top_level_domain/TopLevelDomain.go
+++ b/uri/top_level_domain/TopLevelDomain.go
@@ -9,17 +9,17 @@ type TopLevelDomain struct {
 	value string
 }
 
-func New(value string) (*TopLevelDomain, error) {
+func New(value string) (TopLevelDomain, error) {
 	length := len([]rune(value))
 	if length < 1 {
-		return &TopLevelDomain{}, errors.New("The top level domain value must be atleast one (1) character.")
+		return TopLevelDomain{}, errors.New("The top level domain value must be atleast one (1) character.")
 	}
 
 	if !isOnlyLetters(value) {
-		return &TopLevelDomain{}, errors.New("The top level domain value can only be letters.")
+		return TopLevelDomain{}, errors.New("The top level domain value can only be letters.")
 	}
 
-	return &TopLevelDomain{
+	return TopLevelDomain{
 		value: value,
 	}, nil
 }

--- a/uri/top_level_domain/TopLevelDomain.go
+++ b/uri/top_level_domain/TopLevelDomain.go
@@ -28,7 +28,7 @@ func (tld *TopLevelDomain) Value() string {
 	return tld.value
 }
 
-func (tld *TopLevelDomain) Equals(compare *TopLevelDomain) bool {
+func (tld *TopLevelDomain) Equals(compare TopLevelDomain) bool {
 	return tld.Value() == compare.Value()
 }
 

--- a/uri/top_level_domain/TopLevelDomain_test.go
+++ b/uri/top_level_domain/TopLevelDomain_test.go
@@ -57,7 +57,7 @@ func Test_TwoSameTopLevelDomainMustEqual(t *testing.T) {
 
 func Test_MustReturnErrorForNumberInString(t *testing.T) {
 
-	tld, err := New("1io")
+	_, err := New("1io")
 
 	// Fatal use to end test if an error obejct was not returned because the expessions after this evaluate the error object
 	if err == nil {
@@ -72,7 +72,7 @@ func Test_MustReturnErrorForNumberInString(t *testing.T) {
 
 func Test_MustReturnErrorForSymbolInString(t *testing.T) {
 
-	tld, err := New("com-")
+	_, err := New("com-")
 
 	// Fatal use to end test if an error obejct was not returned because the expessions after this evaluate the error object
 	if err == nil {

--- a/uri/top_level_domain/TopLevelDomain_test.go
+++ b/uri/top_level_domain/TopLevelDomain_test.go
@@ -21,7 +21,8 @@ func Test_InstantiateTopLevelDomain(t *testing.T) {
 
 func Test_MustReturnErrorForEmptyString(t *testing.T) {
 
-	tld, err := New("")
+
+	_, err := New("")
 
 	// Fatal use to end test if an error obejct was not returned because the expessions after this evaluate the error object
 	if err == nil {
@@ -30,9 +31,6 @@ func Test_MustReturnErrorForEmptyString(t *testing.T) {
 
 	if err.Error() != "The top level domain value must be atleast one (1) character." {
 		t.Error("The following expected error message was not returned: 'The top level domain value must be atleast one (1) character.'.")
-	}
-	if tld == nil {
-		t.Error("Expected an instantiated, empty, TopLeveLDomain object, but got a 'nil' value.")
 	}
 
 }
@@ -69,9 +67,6 @@ func Test_MustReturnErrorForNumberInString(t *testing.T) {
 	if err.Error() != "The top level domain value can only be letters." {
 		t.Error("The following expected error message was not returned: 'The top level domain value can only be letters.'.")
 	}
-	if tld == nil {
-		t.Error("Expected an instantiated, empty, TopLeveLDomain object, but got a 'nil' value.")
-	}
 
 }
 
@@ -86,9 +81,6 @@ func Test_MustReturnErrorForSymbolInString(t *testing.T) {
 
 	if err.Error() != "The top level domain value can only be letters." {
 		t.Error("The following expected error message was not returned: 'The top level domain value can only be letters.'.")
-	}
-	if tld == nil {
-		t.Error("Expected an instantiated, empty, TopLeveLDomain object, but got a 'nil' value.")
 	}
 
 }

--- a/uri/top_level_domain/TopLevelDomain_test.go
+++ b/uri/top_level_domain/TopLevelDomain_test.go
@@ -4,10 +4,14 @@ import (
 	"testing"
 )
 
+func setup(t *testing.T) {
+	t.Parallel()
+}
+
 /** Happy Path **/
 
 func Test_InstantiateTopLevelDomain(t *testing.T) {
-
+	setup(t)
 	tld, err := New("io")
 
 	if err != nil {
@@ -20,8 +24,7 @@ func Test_InstantiateTopLevelDomain(t *testing.T) {
 }
 
 func Test_MustReturnErrorForEmptyString(t *testing.T) {
-
-
+	setup(t)
 	_, err := New("")
 
 	// Fatal use to end test if an error obejct was not returned because the expessions after this evaluate the error object
@@ -36,7 +39,7 @@ func Test_MustReturnErrorForEmptyString(t *testing.T) {
 }
 
 func Test_TwoSameTopLevelDomainMustEqual(t *testing.T) {
-
+	setup(t)
 	// Act
 	tld1, err := New("io")
 	tld2, err := New("io")
@@ -53,10 +56,10 @@ func Test_TwoSameTopLevelDomainMustEqual(t *testing.T) {
 
 }
 
-/** Happy Path **/
+/** Sad Path **/
 
 func Test_MustReturnErrorForNumberInString(t *testing.T) {
-
+	setup(t)
 	_, err := New("1io")
 
 	// Fatal use to end test if an error obejct was not returned because the expessions after this evaluate the error object
@@ -71,7 +74,7 @@ func Test_MustReturnErrorForNumberInString(t *testing.T) {
 }
 
 func Test_MustReturnErrorForSymbolInString(t *testing.T) {
-
+	setup(t)
 	_, err := New("com-")
 
 	// Fatal use to end test if an error obejct was not returned because the expessions after this evaluate the error object
@@ -86,7 +89,7 @@ func Test_MustReturnErrorForSymbolInString(t *testing.T) {
 }
 
 func Test_TwoDifferentDomainNameMustNotEqual(t *testing.T) {
-
+	setup(t)
 	// Act
 	tld1, err := New("io")
 	tld2, err := New("com")


### PR DESCRIPTION
The constructors for all value objects were updated to return values instead of pointers.  Any other function that took an argument of a pointer to a value object was updated to reflect the value instead. 

Given value, objects are meant to be immutable, there is no need to pass a pointer.  We reserve pointers for two reasons.  First, if the object is meant to be mutated by other functions.  Secondly, if the object is so large that passing by the pointer is more performant.