### PR TITLE
Added AlreadyExists custom error

### DIFF
--- a/error/already_exists/already_exists.go
+++ b/error/already_exists/already_exists.go
@@ -1,0 +1,18 @@
+package already_exists
+
+// AlreadyExists indicates that an action to create a new entity was unsuccessful
+// because the entity being created already exists/.
+// The message container IS MEANT to be for end users.
+type AlreadyExists struct {
+	message string
+}
+
+func New(message string) AlreadyExists {
+	return AlreadyExists{
+		message: message,
+	}
+}
+
+func (error AlreadyExists) Error() string {
+	return error.message
+}

--- a/error/already_exists/already_exists_test.go
+++ b/error/already_exists/already_exists_test.go
@@ -1,0 +1,22 @@
+package already_exists_test
+
+import (
+	"github.com/attestify/go-kernel/error/already_exists"
+	"testing"
+)
+
+func setup(t *testing.T) {
+	t.Parallel()
+}
+
+func Test_Instantiate_Error_Successfully(t *testing.T) {
+	setup(t)
+
+	var err error = already_exists.New("Some Already Exists Error")
+
+	expectedMessages := "Some Already Exists Error"
+	if err.Error() != expectedMessages {
+		t.Errorf("the actual error messsage is not the expected error message: \n Actual: %s \n Expected: %s",
+			err.Error(), expectedMessages)
+	}
+}


### PR DESCRIPTION
Create the AlreadyExists custom error to encapsulate the response when an action is made to create an entity, although that entity already exists.